### PR TITLE
User Delete API 구현 (#21)

### DIFF
--- a/server/Controllers/UserController.cs
+++ b/server/Controllers/UserController.cs
@@ -71,9 +71,14 @@ namespace server.Controllers
 
         [HttpDelete]
         [Authorize]
-        public ActionResult Delete()
+        public async Task<ActionResult> Delete()
         {
-            return Unauthorized();
+            JwtSecurityToken jwtToken = HttpContext.GetJwtToken();
+            long id = long.Parse(jwtToken.GetClaimByType("id"));
+
+            await mUserService.Delete(id);
+
+            return Ok();
         }
     }
 }

--- a/server/Controllers/UserController.cs
+++ b/server/Controllers/UserController.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore;
 using server.Attributes;
 using server.DTOs;
 using server.Entities;
+using server.Middlewares;
 using server.Services;
 using server.Utilities;
 
@@ -77,6 +78,8 @@ namespace server.Controllers
             long id = long.Parse(jwtToken.GetClaimByType("id"));
 
             await mUserService.Delete(id);
+
+            JwtMiddleware.BanUser(id, TimeSpan.FromDays(28));
 
             return Ok();
         }

--- a/server/Services/UserService.cs
+++ b/server/Services/UserService.cs
@@ -62,4 +62,17 @@ public class UserService : IUserService
 
         return true;
     }
+
+    public async Task Delete(long id)
+    {
+        UserEntity? user = await mContext.Users.FindAsync(id);
+
+        if (user == null)
+        {
+            throw new Exception("The user with that ID does not exist.");
+        }
+
+        mContext.Users.Remove(user);
+        await mContext.SaveChangesAsync();
+    }
 }


### PR DESCRIPTION
## 개요
사용자 정보를 삭제하는 API를 구현하였습니다.

## 수정사항
- Delete Controller, Service 추가
- 사용자 정보 삭제후 이미 발급된 JWT에 대해서 차단 기능 추가